### PR TITLE
Fix for PhantomJS

### DIFF
--- a/src/utils/environment-detection.ts
+++ b/src/utils/environment-detection.ts
@@ -1,9 +1,12 @@
 import {EnvironmentSupport} from '../types';
 
 /**
- * `true` if we are running inside a web browser, `false` otherwise (e.g. running inside Node.js). 
+ * `true` if we are running inside a web browser, `false` otherwise (e.g. running inside Node.js).
+ *
+ * HTMLMediaElement is not supported in PhantomJS
+ * @see https://github.com/ariya/phantomjs/issues/10839
  */
-export const isBrowser = typeof window !== 'undefined';
+export const isBrowser = typeof window !== 'undefined' && typeof window.PHANTOMJS === 'undefined';
 
 /**
  * This is a map which lists native support of formats and APIs.

--- a/src/utils/environment-detection.ts
+++ b/src/utils/environment-detection.ts
@@ -6,7 +6,7 @@ import {EnvironmentSupport} from '../types';
  * HTMLMediaElement is not supported in PhantomJS
  * @see https://github.com/ariya/phantomjs/issues/10839
  */
-export const isBrowser = typeof window !== 'undefined' && typeof window.PHANTOMJS === 'undefined';
+export const isBrowser = typeof window !== 'undefined' && typeof !/PhantomJS/.test(window.navigator.userAgent);
 
 /**
  * This is a map which lists native support of formats and APIs.


### PR DESCRIPTION
PhantomJS 2.1.1 (Mac OS X 0.0.0) ERROR
  TypeError: undefined is not a constructor (evaluating 'video.canPlayType('application/x-mpegURL')')
  at /vidi/dist/src/utils/environment-detection.js:23:0